### PR TITLE
Add html validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ minimized code for production. JS/TS, CSS/SCSS/SASS ready.
     - [Typescript](#typescript)
     - [Favicon](#favicon)
     - [Source Maps](#source-maps)
+    - [HTML Validation](#html-validation)
   - [Production](#production)
 - [Implemented functionality](#implemented-functionality)
 - [Planned functionality](#planned-functionality)
@@ -106,6 +107,15 @@ live sites, and the lack of them does not really make your code more secure.
 **If you are storing secrets or API keys in front-end JavaScript then they are
 insecure regardless!!**
 
+#### HTML Validation
+
+This is run automantically on HTML files, and will fail the build or dev-server
+if there are any errors. However, due to constraints with the plugin used, this
+needs html-validate installed globally to work, even though it's part of the
+build system development dependencies.
+
+`npm i -g html-validate` or `yarn add html-validate -D`
+
 ### Production
 
 Once your code is ready to go live, you can create an optimized and minimized
@@ -132,7 +142,7 @@ folder can be served from any standard web server or GH-Pages / Netlify etc.
 - Babel for Javascript files to transpile to backwards-compatible code.
 - JS and CSS are compressed and named with a Hash for each code change. The
   HTML file is automatically updated with these.
-- ESLint(JS) and StyleLint(CSS) are run automatically.
+- ESLint(JS), StyleLint(CSS) and HTML-Validate (HTML) are run automatically.
 - SCSS and SASS automatically detected and compiled on the fly.
 - Typescript is integrated. You can use either TS or JS as required.
 - Adds favicon automatically if exists in the `src` folder.
@@ -140,9 +150,6 @@ folder can be served from any standard web server or GH-Pages / Netlify etc.
 
 ## Planned functionality
 
-- html-validate is included for editor integration, but not yet run
-  as part of the webpack process, this is planned and will fail or warn the
-  build if errors.
 - Add PostCSS integration
 - Integrate `favicons-webpack-plugin` to auto generate favicons for different
   devices

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ minimized code for production. JS/TS, CSS/SCSS/SASS ready.
     - [Typescript](#typescript)
     - [Favicon](#favicon)
     - [Source Maps](#source-maps)
-    - [HTML Validation](#html-validation)
+    - [Validation](#validation)
   - [Production](#production)
 - [Implemented functionality](#implemented-functionality)
 - [Planned functionality](#planned-functionality)
@@ -107,14 +107,11 @@ live sites, and the lack of them does not really make your code more secure.
 **If you are storing secrets or API keys in front-end JavaScript then they are
 insecure regardless!!**
 
-#### HTML Validation
+#### Validation
 
-This is run automantically on HTML files, and will fail the build or dev-server
-if there are any errors. However, due to constraints with the plugin used, this
-needs html-validate installed globally to work, even though it's part of the
-build system development dependencies.
-
-`npm i -g html-validate` or `yarn add html-validate -D`
+This is run automatically on HTML files (using `html-validate`), JavaScript
+files (using `ESLint`) and CSS/SCSS/SASS files using `StyleLint`, **The build
+process or dev-server will fail if there are any validation errors!**.
 
 ### Production
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-sonarjs": "^0.14.0",
     "eslint-webpack-plugin": "^3.2.0",
-    "html-validate": "^7.1.2",
+    "html-validate": "^7.2.0",
     "html-validate-webpack-plugin": "^1.2.1",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-sonarjs": "^0.14.0",
     "eslint-webpack-plugin": "^3.2.0",
     "html-validate": "^7.1.2",
+    "html-validate-webpack-plugin": "^1.2.1",
     "html-webpack-plugin": "^5.5.0",
     "mini-css-extract-plugin": "^2.6.1",
     "sass": "^1.54.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,10 +5,11 @@
 /* -------------------------------------------------------------------------- */
 
 const path = require("path");
-const fs=require("fs");
+const fs = require("fs");
 
 const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const ESLintPlugin = require("eslint-webpack-plugin");
+const HtmlValidatePlugin = require("html-validate-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const StylelintPlugin = require("stylelint-webpack-plugin");
@@ -52,7 +53,8 @@ module.exports = (env, argv) => {
       new ESLintPlugin(),
       new StylelintPlugin({
         configFile: ".stylelintrc.json"
-      })
+      }),
+      new HtmlValidatePlugin()
     ].concat(
       devMode
         ? []

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,6 +1476,11 @@ acorn@^8.5.0, acorn@^8.7.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
+ajv-errors@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
+  integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -1483,7 +1488,7 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv-keywords@^3.5.2:
+ajv-keywords@^3.1.0, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
@@ -1495,7 +1500,7 @@ ajv-keywords@^5.0.0:
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -3033,6 +3038,13 @@ html-tags@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.2.0.tgz#dbb3518d20b726524e4dd43de397eb0a95726961"
   integrity sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==
+
+html-validate-webpack-plugin@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/html-validate-webpack-plugin/-/html-validate-webpack-plugin-1.2.1.tgz#1653602380cfdc7e93642efab7b85a636ab95302"
+  integrity sha512-mdyOCwtupb8Fjc8VyDzvagLoOCSAz0K6MF+dzfZv9pAD3CsSofAQKTKRqcPBzOobDwCdzVkGOtK3nHfDHySD3w==
+  dependencies:
+    schema-utils "^1.0.0"
 
 html-validate@^7.1.2:
   version "7.1.2"
@@ -4644,6 +4656,15 @@ sass@^1.54.0:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
+
+schema-utils@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"
+  integrity sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==
+  dependencies:
+    ajv "^6.1.0"
+    ajv-errors "^1.0.0"
+    ajv-keywords "^3.1.0"
 
 schema-utils@^2.6.5:
   version "2.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,7 +1471,7 @@ acorn-walk@^8.0.0:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
@@ -2538,7 +2538,16 @@ eslint@^8.20.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0, espree@^9.3.2:
+espree@^9.0.0:
+  version "9.3.3"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.3.tgz#2dd37c4162bb05f433ad3c1a52ddf8a49dc08e9d"
+  integrity sha512-ORs1Rt/uQTqUKjDdGCyrtYxbazf5umATSf/K4qxjmZHORR6HJk+2s/2Pqe+Kk49HHINC/xNIrGfgh8sZcll0ng==
+  dependencies:
+    acorn "^8.8.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.3.0"
+
+espree@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/espree/-/espree-9.3.2.tgz#f58f77bd334731182801ced3380a8cc859091596"
   integrity sha512-D211tC7ZwouTIuY5x9XnS0E9sWNChB7IYKX/Xp5eQj3nFXhqmiUDB9q27y76oFl8jTg3pXcQx/bpxMfs3CIZbA==
@@ -3046,10 +3055,10 @@ html-validate-webpack-plugin@^1.2.1:
   dependencies:
     schema-utils "^1.0.0"
 
-html-validate@^7.1.2:
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-7.1.2.tgz#ddbeedc7bb71cb63bd567dd874d333be8c25226d"
-  integrity sha512-qodSHSwb76eDWyjiJ15xNI6JED54aRYSQIH13M4AN8u7t+Pvjm1BfFG3VtWE8RmIVkgRCmxkIE3p9weU4AIO1g==
+html-validate@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/html-validate/-/html-validate-7.2.0.tgz#8b69cf5bd630ddc24f1d4c5cff4c56d7b4a0b63c"
+  integrity sha512-AA+DBN6el4FCwH+F4UEO70Kn2ZvVouOhubphVWGIOdssmBg7Q5XKwhOfY187svuFaFRrLqdOGnOtHESiEVErbw==
   dependencies:
     "@babel/code-frame" "^7.10.0"
     "@html-validate/stylish" "^3.0.0"


### PR DESCRIPTION
HTML files are validated similar to JS and CSS files.

the package [html-validate](https://html-validate.org/) is used. Any errors will cause the build to fail.