### PR TITLE
Inline small SVG files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -108,6 +108,11 @@ module.exports = (env, argv) => {
             loader: "ts-loader",
           },
         },
+        {
+          // inline small svg files
+          test: /\.svg$/,
+          type: "asset",
+        },
       ],
     },
     optimization: {


### PR DESCRIPTION
Webpack will auto choose if SVG files should be inlined, depending on their size.