### PR TITLE
Enable CSS modules

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -3,7 +3,8 @@
     "stylelint-config-standard",
     "stylelint-config-prettier",
     "stylelint-config-standard-scss",
-    "stylelint-config-prettier-scss"
+    "stylelint-config-prettier-scss",
+    "stylelint-config-css-modules"
   ],
   "ignoreFiles": [
     "dist/*",
@@ -38,5 +39,15 @@
         "severity": "warning"
       }
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.module.*"
+      ],
+      "rules": {
+        "selector-class-pattern": "^[a-z][a-zA-Z0-9]+$"
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ minimized code for production. JS/TS, CSS/SCSS/SASS ready.
   - [Development](#development)
   - [Specific Notes](#specific-notes)
     - [Stylesheet files](#stylesheet-files)
+      - [CSS Modules](#css-modules)
     - [Typescript](#typescript)
     - [Environment Variables](#environment-variables)
     - [Favicon](#favicon)
@@ -76,7 +77,7 @@ The following notes are of interest.
 
 #### Stylesheet files
 
-your CSS files need to be imported in the JS file instead of the HTML. In a
+Your CSS files need to be imported in the JS file instead of the HTML. In a
 production bundle, these will be combined and extracted then minified. Import
 them at the top of your JS file, for example:
 
@@ -86,6 +87,12 @@ import "./styles/site.css";
 
 You can also use `SASS` or `SCSS` instead of plain CSS, simply by renaming the
 file extensions
+
+##### CSS Modules
+
+[CSS Modules](https://github.com/css-modules/css-modules) are enabled for
+CSS/SCSS and SASS. They should have the file name format of `<NAME>.module.css`
+(or SCSS etc), and are imported as above.
 
 #### Typescript
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sass-loader": "^13.0.2",
     "style-loader": "^3.3.1",
     "stylelint": "^14.10.0",
+    "stylelint-config-css-modules": "^4.1.0",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-prettier-scss": "^0.0.1",
     "stylelint-config-standard": "^27.0.0",

--- a/src/index.html
+++ b/src/index.html
@@ -17,12 +17,12 @@
       <h1>HTML Template</h1>
     </header>
     <main>
+      <p class="big-box">
+        Replace the contents of the HTML/CSS and Javascript files with your own!
+      </p>
       <p class="check" id="js-test">
         If you can read this, the JavaScript is not loading properly! The page
         will be unstyled also.
-      </p>
-      <p class="big-box">
-        Replace the contents of the HTML/CSS and Javascript files with your own!
       </p>
     </main>
     <footer>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 // import the main CSS. This needs to be here
 import "./styles/site.css";
+import styles from "./styles/styles.module.scss";
 
 /* -------------------------------------------------------------------------- */
 /*                remove everything below for your own projects               */
@@ -7,9 +8,10 @@ import "./styles/site.css";
 
 // prove that our JS file is loaded
 const msg =
-  "If you can read this, and the text below is in a blue box then" +
-  " the JavaScript and CSS are imported properly.";
+  "If both these boxes have white text and blue background, then the " +
+  "JavaScript, CSS/SCSS and CSS modules are working properly.";
 document.getElementById("js-test").innerText = msg;
+document.getElementById("js-test").classList.add(`${styles.moduleTest}`);
 
 // Testing that the .env file is read
 console.log(process.env.MY_TEST_VARIABLE);

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-// import the main CSS. This needs to be here
+// import the main CSS. This needs to be first, though you can replace with
+// your own filenames if required.
 import "./styles/site.css";
-import styles from "./styles/styles.module.scss";
-
 /* -------------------------------------------------------------------------- */
 /*                remove everything below for your own projects               */
 /* -------------------------------------------------------------------------- */
+import styles from "./styles/styles.module.scss";
 
 // prove that our JS file is loaded
 const msg =

--- a/src/styles/styles.module.scss
+++ b/src/styles/styles.module.scss
@@ -1,0 +1,9 @@
+.moduleTest {
+  background-color: hsl(203, 100%, 50%);
+  color: white;
+  width: 90%;
+  padding: 0.5em;
+  border-radius: 1em;
+  text-align: center;
+  margin: 1em auto;
+}

--- a/src/styles/styles.module.scss
+++ b/src/styles/styles.module.scss
@@ -6,4 +6,5 @@
   border-radius: 1em;
   text-align: center;
   margin: 1em auto;
+  box-shadow: 0 10px 13px -7px #000;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,9 +88,22 @@ module.exports = (_env, argv) => {
           test: /\.(sa|sc|c)ss$/,
           use: [
             devMode ? "style-loader" : MiniCssExtractPlugin.loader,
+            {
+              loader: "css-loader",
+              options: { importLoaders: 1, modules: true },
+            },
+            "sass-loader",
+          ],
+          include: /\.module\.(sa|sc|c)ss$/,
+        },
+        {
+          test: /\.(sa|sc|c)ss$/,
+          use: [
+            devMode ? "style-loader" : MiniCssExtractPlugin.loader,
             "css-loader",
             "sass-loader",
           ],
+          exclude: /\.module\.(sa|sc|c)ss$/,
         },
         {
           test: /\.js$/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -90,7 +90,15 @@ module.exports = (_env, argv) => {
             devMode ? "style-loader" : MiniCssExtractPlugin.loader,
             {
               loader: "css-loader",
-              options: { importLoaders: 1, modules: true },
+              options: {
+                importLoaders: 1,
+                modules: {
+                  auto: true,
+                  localIdentName: devMode
+                    ? "[name]__[local]___[hash:base64:5]"
+                    : "[hash:base64]",
+                },
+              },
             },
             "sass-loader",
           ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,7 @@ module.exports = (_env, argv) => {
                 modules: {
                   auto: true,
                   localIdentName: devMode
-                    ? "[name]__[local]___[hash:base64:5]"
+                    ? "[path][name]__[local]"
                     : "[hash:base64]",
                 },
               },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5067,6 +5067,13 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
+stylelint-config-css-modules@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-css-modules/-/stylelint-config-css-modules-4.1.0.tgz#b507bc074ba5bfda9f40f0be79b540db249f0c78"
+  integrity sha512-w6d552NscwvpUEaUcmq8GgWXKRv6lVHLbDj6QIHSM2vCWr83qRqRvXBJCfXDyaG/J3Zojw2inU9VvU99ZlXuUw==
+  optionalDependencies:
+    stylelint-scss "^4.2.0"
+
 stylelint-config-prettier-scss@^0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier-scss/-/stylelint-config-prettier-scss-0.0.1.tgz#22feaa28c6ca07e74be34c8506219fa4e2c34886"
@@ -5120,7 +5127,7 @@ stylelint-config-standard@^27.0.0:
   dependencies:
     stylelint-config-recommended "^9.0.0"
 
-stylelint-scss@^4.0.0:
+stylelint-scss@^4.0.0, stylelint-scss@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.3.0.tgz#638800faf823db11fff60d537c81051fe74c90fa"
   integrity sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==


### PR DESCRIPTION
Enable CSS Modules for CSS/SCSS/SASS files. 

The filename must be in the format `<name>.module.css` (or SCSS/SASS). 
Normal style files will still be processed as standard global styles.